### PR TITLE
misc: typo in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ pyright: uv-installed ## run pyright
 tests: pytest filecheck ## run functional tests
 
 .PHONY: tests
-tests: test-functional pyright ## run all tests
+tests: tests-functional pyright ## run all tests
 
 .PHONY: docs
 docs: uv-installed ## Build and serve documentation


### PR DESCRIPTION
Typoed `tests-functional` at some point during the changes and this seems to not be used by ci