### PR TITLE
CI: don't prune CI cache

### DIFF
--- a/.github/workflows/ci-code-formatting.yml
+++ b/.github/workflows/ci-code-formatting.yml
@@ -22,7 +22,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-          prune-cache: false
 
       - name: Set up Python 3.14
         uses: actions/setup-python@v7

--- a/.github/workflows/ci-code-formatting.yml
+++ b/.github/workflows/ci-code-formatting.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          prune-cache: false
 
       - name: Set up Python 3.14
         uses: actions/setup-python@v7
@@ -30,6 +31,3 @@ jobs:
 
       - name: Run code formatting checks with prek
         uses: j178/prek-action@v2
-
-      - name: Prune uv cache
-        run: uv cache prune --ci

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          prune-cache: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
@@ -38,6 +39,3 @@ jobs:
       - name: Run all tests
         run: |
           make tests-functional
-
-      - name: Prune uv cache
-        run: uv cache prune --ci

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-          prune-cache: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7

--- a/.github/workflows/ci-lockfile.yml
+++ b/.github/workflows/ci-lockfile.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          prune-cache: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
@@ -37,6 +38,3 @@ jobs:
           # Install all default extras.
           # Fail if the lockfile dependencies are out of date with pyproject.toml.
           uv sync --all-extras --all-groups --locked
-
-      - name: Prune uv cache
-        run: uv cache prune --ci

--- a/.github/workflows/ci-lockfile.yml
+++ b/.github/workflows/ci-lockfile.yml
@@ -26,7 +26,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-          prune-cache: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7

--- a/.github/workflows/ci-pyright.yml
+++ b/.github/workflows/ci-pyright.yml
@@ -29,7 +29,6 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
-          prune-cache: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7

--- a/.github/workflows/ci-pyright.yml
+++ b/.github/workflows/ci-pyright.yml
@@ -29,6 +29,7 @@ jobs:
         with:
           enable-cache: true
           cache-dependency-glob: "uv.lock"
+          prune-cache: false
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v7
@@ -45,6 +46,3 @@ jobs:
         with:
           version: PATH
           venv-path: .venv
-
-      - name: Prune uv cache
-        run: uv cache prune --ci


### PR DESCRIPTION
It turns out that the cache pruning with `--ci` flag is not really meant for pure-Python workloads, it prunes everything except for pre-built packages, but we don't have any here. The CI cache is hashed based on the uv.lock file, so if any of the dependencies change the whole cache is changed anyway, and the old ones will be evicted, so there's nothing really that we should do. The default behavior of setup-uv also includes the cache pruning (not true for very latest uv action but that's not the one we're using yet, and it's not clear how they'll change the default in the future).